### PR TITLE
fix: 修复新建用户弹窗的表单问题

### DIFF
--- a/packages/admin/src/pages/system/setting/UserManagement.tsx
+++ b/packages/admin/src/pages/system/setting/UserManagement.tsx
@@ -29,7 +29,14 @@ export default (): React.ReactElement => {
     <>
       <ProList<string>
         actions={[
-          <Button key="new" type="primary" onClick={() => setModalVisible(true)}>
+          <Button
+            key="new"
+            type="primary"
+            onClick={() => {
+              setSelectedUser(undefined)
+              setModalVisible(true)
+            }}
+          >
             <PlusOutlined /> 新建
           </Button>,
         ]}


### PR DESCRIPTION
在用户管理界面,点击新建用户按钮时,弹窗表单不是空表单,而是填充了未知用户信息